### PR TITLE
Add possibility to specify issue title

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,9 +9,11 @@ var argv = require('minimist')(process.argv.slice(2), {
   }
 })
 
+const title = argv['t'] ? argv['t'] : `Please pin this hash`
+
 if (argv['test']) {
   createIssue({
-    title: `Please pin this hash`,
+    title: title,
     template: 'templates/issue.md',
     repo: 'RichardLitt/ping-ops-requests',
     hash: argv['h'],
@@ -19,7 +21,7 @@ if (argv['test']) {
   })
 } else if (argv['h'] && argv['d']) {
   createIssue({
-    title: `Please pin this hash`,
+    title: title,
     template: 'templates/issue.md',
     repo: 'ipfs/ops-requests',
     hash: argv['h'],


### PR DESCRIPTION
I realized the default title "Please pin this hash" is a little non-descriptive for deploying orbit-web, so I added the possibility here to define it by passing it via flag `t`.
